### PR TITLE
Updated FileWorker to complete the claim on the fail after writing the file + test updates

### DIFF
--- a/the-incredible-bulk/src/main/java/gov/va/api/health/bulkfhir/service/controller/publication/DefaultPublicationStatusTransformer.java
+++ b/the-incredible-bulk/src/main/java/gov/va/api/health/bulkfhir/service/controller/publication/DefaultPublicationStatusTransformer.java
@@ -64,11 +64,11 @@ public class DefaultPublicationStatusTransformer implements PublicationStatusTra
     void add(BuildStatus status) {
       if (status == BuildStatus.IN_PROGRESS) {
         inProgress++;
-      }
-      if (status == BuildStatus.COMPLETE) {
+      } else if (status == BuildStatus.COMPLETE) {
         completed++;
+      } else {
+        notStarted++;
       }
-      notStarted++;
     }
 
     BuildStatus overallStatus() {

--- a/the-incredible-bulk/src/main/java/gov/va/api/health/bulkfhir/service/controller/publication/OptimisticFileClaimant.java
+++ b/the-incredible-bulk/src/main/java/gov/va/api/health/bulkfhir/service/controller/publication/OptimisticFileClaimant.java
@@ -38,6 +38,7 @@ public class OptimisticFileClaimant implements FileClaimant {
   public void completeClaim(FileBuildRequest request) {
     StatusEntity entity = findStatusEntity(request);
     entity.buildCompleteEpoch(System.currentTimeMillis());
+    repository.saveAndFlush(entity);
   }
 
   private StatusEntity findStatusEntity(FileBuildRequest request) {

--- a/the-incredible-bulk/src/test/java/gov/va/api/health/bulkfhir/service/controller/publication/DefaultPublicationStatusTransformerTest.java
+++ b/the-incredible-bulk/src/test/java/gov/va/api/health/bulkfhir/service/controller/publication/DefaultPublicationStatusTransformerTest.java
@@ -8,6 +8,46 @@ import org.junit.jupiter.api.Test;
 
 public class DefaultPublicationStatusTransformerTest {
 
+  @Test
+  void addingCompleteToCounterIsMarkedComplete() {
+    Counter counter = new Counter();
+    counter.add(BuildStatus.COMPLETE);
+    assertThat(counter.notStarted).isEqualTo(0);
+    assertThat(counter.inProgress).isEqualTo(0);
+    assertThat(counter.completed).isEqualTo(1);
+    assertThat(counter.overallStatus()).isEqualByComparingTo(BuildStatus.COMPLETE);
+  }
+
+  @Test
+  void addingToCounterKeepsAccurateCount() {
+    Counter counter = new Counter();
+    counter.add(BuildStatus.NOT_STARTED);
+    assertThat(counter.notStarted).isEqualTo(1);
+    assertThat(counter.inProgress).isEqualTo(0);
+    assertThat(counter.completed).isEqualTo(0);
+    assertThat(counter.overallStatus()).isEqualByComparingTo(BuildStatus.NOT_STARTED);
+    counter.add(BuildStatus.NOT_STARTED);
+    assertThat(counter.notStarted).isEqualTo(2);
+    assertThat(counter.inProgress).isEqualTo(0);
+    assertThat(counter.completed).isEqualTo(0);
+    assertThat(counter.overallStatus()).isEqualByComparingTo(BuildStatus.NOT_STARTED);
+    counter.add(BuildStatus.IN_PROGRESS);
+    assertThat(counter.notStarted).isEqualTo(2);
+    assertThat(counter.inProgress).isEqualTo(1);
+    assertThat(counter.completed).isEqualTo(0);
+    assertThat(counter.overallStatus()).isEqualByComparingTo(BuildStatus.IN_PROGRESS);
+    counter.add(BuildStatus.IN_PROGRESS);
+    assertThat(counter.notStarted).isEqualTo(2);
+    assertThat(counter.inProgress).isEqualTo(2);
+    assertThat(counter.completed).isEqualTo(0);
+    assertThat(counter.overallStatus()).isEqualByComparingTo(BuildStatus.IN_PROGRESS);
+    counter.add(BuildStatus.COMPLETE);
+    assertThat(counter.notStarted).isEqualTo(2);
+    assertThat(counter.inProgress).isEqualTo(2);
+    assertThat(counter.completed).isEqualTo(1);
+    assertThat(counter.overallStatus()).isEqualByComparingTo(BuildStatus.IN_PROGRESS);
+  }
+
   private Counter counter(int notStarted, int inProgress, int complete) {
     var c = new Counter();
     c.notStarted = notStarted;

--- a/the-incredible-bulk/src/test/java/gov/va/api/health/bulkfhir/service/controller/publication/NonDistributedFileWorkerTest.java
+++ b/the-incredible-bulk/src/test/java/gov/va/api/health/bulkfhir/service/controller/publication/NonDistributedFileWorkerTest.java
@@ -65,10 +65,12 @@ public class NonDistributedFileWorkerTest {
   void fileWriterIsGivenTheProperDataToWrite() {
     when(dq.requestPatients(3, 1234)).thenReturn(refactorMeToBeReusableSamplePatients());
     when(objectMapper.writeValueAsString(any())).thenReturn("HI");
-    worker().buildFile(claim());
+    FileClaim claim = claim();
+    worker().buildFile(claim);
     ArgumentCaptor<FileClaim> fileClaim = ArgumentCaptor.forClass(FileClaim.class);
     ArgumentCaptor<Stream<String>> resourceStream = ArgumentCaptor.forClass(Stream.class);
     verify(fileWriter).writeFile(fileClaim.capture(), resourceStream.capture());
+    verify(claimant).completeClaim(claim.request());
     assertThat(fileClaim.getValue()).isEqualTo(claim());
     assertThat(resourceStream.getValue().count()).isEqualTo(1);
   }

--- a/the-incredible-bulk/src/test/java/gov/va/api/health/bulkfhir/service/controller/publication/OptimisticFileClaimantTest.java
+++ b/the-incredible-bulk/src/test/java/gov/va/api/health/bulkfhir/service/controller/publication/OptimisticFileClaimantTest.java
@@ -43,6 +43,7 @@ class OptimisticFileClaimantTest {
 
     claimant().completeClaim(FileBuildRequest.builder().publicationId("p").fileId("f").build());
     assertThat(e.buildCompleteEpoch()).isNotZero();
+    verify(repo).saveAndFlush(e);
   }
 
   OptimisticFileClaimant claimant() {


### PR DESCRIPTION
* NonDistributedFileWorker now completes the claim after successful writing of the file