### PR TITLE
SHANK-72 Publication Status endpoint

### DIFF
--- a/bulk
+++ b/bulk
@@ -27,8 +27,17 @@ delete [--publication-id <id>]
   Delete a specific publication
 
 build [--publication-id <id>] --file-id <id>
+  Build the specified file for the specified publication
 
 next
+  Build the next file for the oldest non-completed publication
+
+export
+  Ask for the export information for the most recently completed publication
+
+status
+  Ask for the status (file location) information about the most recently completed publication
+  This will call the export endpoint and parse out the status url with encoded ID from that response
 
 EOF
 exit 1
@@ -96,6 +105,22 @@ doExport() {
     -w "%{http_code}" \
     $EXPORT_URL?_outputFormat=ndjson)
   printResponse "$activity" "$status" $WORK/response.json
+}
+
+doGetPublicationStatus() {
+  local statusUrl=$(curl -sH Content-Type:application/json \
+    -H Accept:application/json \
+    -H Prefer:respond-async \
+    $EXPORT_URL?_outputFormat=ndjson -I \
+    | grep -Fi Content-Location \
+    | cut -d" " -f2 \
+    | tr -d "[:space:]")
+  local status=$(curl -sH Content-Type:application/json \
+    -H Accept:application/json \
+    -o $WORK/response.json \
+    -w "%{http_code}" \
+    $statusUrl)
+  printResponse "Getting most recent publication status" "$status" $WORK/response.json
 }
 
 doGet() {
@@ -172,6 +197,7 @@ case $COMMAND in
   g|get) doGet;;
   l|list) doList;;
   e|export) doExport;;
+  s|status) doGetPublicationStatus;;
   *) usage "Unknown command: $COMMAND";;
 esac
 

--- a/bulk-fhir-api/src/main/java/gov/va/api/health/bulkfhir/api/bulkstatus/PublicationFileStatusResponse.java
+++ b/bulk-fhir-api/src/main/java/gov/va/api/health/bulkfhir/api/bulkstatus/PublicationFileStatusResponse.java
@@ -1,23 +1,23 @@
 package gov.va.api.health.bulkfhir.api.bulkstatus;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import lombok.Builder;
-import lombok.Value;
-
-import javax.validation.constraints.NotEmpty;
-import javax.validation.constraints.NotNull;
 import java.time.Instant;
 import java.util.List;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import lombok.Builder;
+import lombok.Value;
 
 @Value
 @Builder
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public class PublicationFileStatusResponse {
-  @NotNull
-  boolean requiresAccessToken;
+  @NotNull boolean requiresAccessToken;
 
-  @NotNull
-  String request;
+  @NotNull String request;
 
   @NotNull Instant creationDate;
 
@@ -25,14 +25,29 @@ public class PublicationFileStatusResponse {
 
   @NotEmpty List<FileLocation> error;
 
+  @NotNull Extension extension;
+
   @Value
   @Builder
   @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
   public static class FileLocation {
-    @NotNull
-    String type;
+    @NotNull String type;
 
+    @NotNull String url;
+  }
+
+  @Value
+  @Builder
+  @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+  public static class Extension {
     @NotNull
-    String url;
+    @Pattern(regexp = "[-A-Za-z0-9]{8,64}")
+    String id;
+
+    @Min(1)
+    @Max(500_000)
+    int recordsPerFile;
+
+    @NotNull Instant creationDate;
   }
 }

--- a/bulk-fhir-api/src/main/java/gov/va/api/health/bulkfhir/api/bulkstatus/PublicationFileStatusResponse.java
+++ b/bulk-fhir-api/src/main/java/gov/va/api/health/bulkfhir/api/bulkstatus/PublicationFileStatusResponse.java
@@ -1,0 +1,38 @@
+package gov.va.api.health.bulkfhir.api.bulkstatus;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import lombok.Builder;
+import lombok.Value;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import java.time.Instant;
+import java.util.List;
+
+@Value
+@Builder
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+public class PublicationFileStatusResponse {
+  @NotNull
+  boolean requiresAccessToken;
+
+  @NotNull
+  String request;
+
+  @NotNull Instant creationDate;
+
+  @NotEmpty List<FileLocation> output;
+
+  @NotEmpty List<FileLocation> error;
+
+  @Value
+  @Builder
+  @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+  public static class FileLocation {
+    @NotNull
+    String type;
+
+    @NotNull
+    String url;
+  }
+}

--- a/bulk-fhir-api/src/main/java/gov/va/api/health/bulkfhir/api/bulkstatus/PublicationFileStatusResponse.java
+++ b/bulk-fhir-api/src/main/java/gov/va/api/health/bulkfhir/api/bulkstatus/PublicationFileStatusResponse.java
@@ -3,6 +3,7 @@ package gov.va.api.health.bulkfhir.api.bulkstatus;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
@@ -25,7 +26,7 @@ public class PublicationFileStatusResponse {
 
   List<FileLocation> error;
 
-  Extension extension;
+  Optional<Extension> extension;
 
   @Value
   @Builder
@@ -35,7 +36,7 @@ public class PublicationFileStatusResponse {
 
     @NotNull String url;
 
-    Integer count;
+    Optional<Integer> count;
   }
 
   @Value

--- a/bulk-fhir-api/src/main/java/gov/va/api/health/bulkfhir/api/bulkstatus/PublicationFileStatusResponse.java
+++ b/bulk-fhir-api/src/main/java/gov/va/api/health/bulkfhir/api/bulkstatus/PublicationFileStatusResponse.java
@@ -19,13 +19,13 @@ public class PublicationFileStatusResponse {
 
   @NotNull String request;
 
-  @NotNull Instant creationDate;
+  @NotNull Instant transactionTime;
 
   @NotEmpty List<FileLocation> output;
 
   List<FileLocation> error;
 
-  @NotNull Extension extension;
+  Extension extension;
 
   @Value
   @Builder
@@ -34,6 +34,8 @@ public class PublicationFileStatusResponse {
     @NotNull String type;
 
     @NotNull String url;
+
+    Integer count;
   }
 
   @Value

--- a/bulk-fhir-api/src/main/java/gov/va/api/health/bulkfhir/api/bulkstatus/PublicationFileStatusResponse.java
+++ b/bulk-fhir-api/src/main/java/gov/va/api/health/bulkfhir/api/bulkstatus/PublicationFileStatusResponse.java
@@ -23,7 +23,7 @@ public class PublicationFileStatusResponse {
 
   @NotEmpty List<FileLocation> output;
 
-  @NotEmpty List<FileLocation> error;
+  List<FileLocation> error;
 
   @NotNull Extension extension;
 

--- a/bulk-fhir-tests/src/test/java/gov/va/api/health/bulkfhir/tests/PublicationIT.java
+++ b/bulk-fhir-tests/src/test/java/gov/va/api/health/bulkfhir/tests/PublicationIT.java
@@ -6,6 +6,7 @@ import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
 import gov.va.api.health.autoconfig.configuration.JacksonConfig;
+import gov.va.api.health.bulkfhir.api.bulkstatus.PublicationFileStatusResponse;
 import gov.va.api.health.bulkfhir.api.internal.ClearHungRequest;
 import gov.va.api.health.bulkfhir.api.internal.FileBuildResponse;
 import gov.va.api.health.bulkfhir.api.internal.PublicationRequest;
@@ -24,7 +25,7 @@ import org.junit.experimental.categories.Category;
 import org.mockserver.integration.ClientAndServer;
 
 @Slf4j
-public class InternalPublicationIT {
+public class PublicationIT {
 
   @Test
   @Category({Local.class})
@@ -57,6 +58,14 @@ public class InternalPublicationIT {
       /* Delete it, then try to delete it again */
       endpoint.deletePublication("errorCodes-1").expect(200);
       endpoint.deletePublication("errorCodes-1").expect(404);
+      /* Check error states for the bulk status endpoint */
+      BulkStatusEndpoint bulkStatusEndpoint = BulkStatusEndpoint.create();
+      bulkStatusEndpoint.getBulkStatus("CANTDECODEME").expect(404);
+      bulkStatusEndpoint.getBulkStatusWithoutHeader("DOESNTMATTER").expect(400);
+      /* Valid decodable id with no data */
+      bulkStatusEndpoint
+          .getBulkStatus("I2-UZHTGVLJAFI4RMSCAYRQ5JENTLTEIKKGVI6UJM7WJMMGJCB44EHA0000")
+          .expect(404);
     }
   }
 
@@ -94,11 +103,24 @@ public class InternalPublicationIT {
       PublicationStatus status =
           endpoint.getPublication("fullCycle-1").expect(200).expectValid(PublicationStatus.class);
       assertThat(status.publicationId()).isEqualTo("fullCycle-1");
-      /* Build next file */
+      /* Build next file twice, to fully build the publication */
       FileBuildResponse fileBuildResponse =
           endpoint.buildNextFile().expect(202).expectValid(FileBuildResponse.class);
       assertThat(fileBuildResponse.publicationId()).isEqualTo("fullCycle-1");
       assertThat(fileBuildResponse.fileId()).isEqualTo("Patient-0001");
+      FileBuildResponse fileBuildResponse2 =
+          endpoint.buildNextFile().expect(202).expectValid(FileBuildResponse.class);
+      assertThat(fileBuildResponse2.publicationId()).isEqualTo("fullCycle-1");
+      assertThat(fileBuildResponse2.fileId()).isEqualTo("Patient-0002");
+      /* Get the status for the completed publication */
+      BulkStatusEndpoint bulkStatusEndpoint = BulkStatusEndpoint.create();
+      PublicationFileStatusResponse publicationStatusResponse =
+          bulkStatusEndpoint
+              .getBulkStatus("I2-UZHTGVLJAFI4RMSCAYRQ5JENTLTEIKKGVI6UJM7WJMMGJCB44EHA0000")
+              .expect(200)
+              .expectValid(PublicationFileStatusResponse.class);
+      assertThat(publicationStatusResponse.extension().id()).isEqualTo("fullCycle-1");
+      assertThat(publicationStatusResponse.output().size()).isEqualTo(2);
       /* Delete both */
       endpoint.deletePublication("fullCycle-1").expect(200);
       assertThat(endpoint.listPublications().expect(200).expectListOf(String.class))
@@ -207,6 +229,37 @@ public class InternalPublicationIT {
     String url() {
       return SystemDefinitions.systemDefinition().bulkFhir().urlWithApiPath()
           + "internal/publication";
+    }
+  }
+
+  @NoArgsConstructor(staticName = "create")
+  static class BulkStatusEndpoint {
+
+    private Header acceptHeader() {
+      return new Header("accept", "application/json");
+    }
+
+    ExpectedResponse getBulkStatus(String encodedId) {
+      return ExpectedResponse.of(
+          TestClients.bulkFhir()
+              .service()
+              .requestSpecification()
+              .header(acceptHeader())
+              .contentType("application/json")
+              .request(Method.GET, url() + "/" + encodedId));
+    }
+
+    ExpectedResponse getBulkStatusWithoutHeader(String encodedId) {
+      return ExpectedResponse.of(
+          TestClients.bulkFhir()
+              .service()
+              .requestSpecification()
+              .contentType("application/json")
+              .request(Method.GET, url() + "/" + encodedId));
+    }
+
+    String url() {
+      return SystemDefinitions.systemDefinition().bulkFhir().urlWithApiPath() + "bulk";
     }
   }
 }

--- a/bulk-fhir-tests/src/test/java/gov/va/api/health/bulkfhir/tests/PublicationIT.java
+++ b/bulk-fhir-tests/src/test/java/gov/va/api/health/bulkfhir/tests/PublicationIT.java
@@ -119,7 +119,8 @@ public class PublicationIT {
               .getBulkStatus("I2-UZHTGVLJAFI4RMSCAYRQ5JENTLTEIKKGVI6UJM7WJMMGJCB44EHA0000")
               .expect(200)
               .expectValid(PublicationFileStatusResponse.class);
-      assertThat(publicationStatusResponse.extension().id()).isEqualTo("fullCycle-1");
+      assertThat(publicationStatusResponse.extension().isPresent()).isTrue();
+      assertThat(publicationStatusResponse.extension().get().id()).isEqualTo("fullCycle-1");
       assertThat(publicationStatusResponse.output().size()).isEqualTo(2);
       /* Delete both */
       endpoint.deletePublication("fullCycle-1").expect(200);

--- a/the-incredible-bulk/src/main/java/gov/va/api/health/bulkfhir/service/controller/bulkstatus/BulkStatusController.java
+++ b/the-incredible-bulk/src/main/java/gov/va/api/health/bulkfhir/service/controller/bulkstatus/BulkStatusController.java
@@ -1,0 +1,85 @@
+package gov.va.api.health.bulkfhir.service.controller.bulkstatus;
+
+import gov.va.api.health.bulkfhir.api.bulkstatus.PublicationFileStatusResponse;
+import gov.va.api.health.bulkfhir.service.status.StatusEntity;
+import gov.va.api.health.bulkfhir.service.status.StatusRepository;
+import gov.va.api.health.ids.api.IdentityService;
+import gov.va.api.health.ids.api.ResourceIdentity;
+import java.time.Instant;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Builder;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@Validated
+@RestController
+@RequestMapping(
+  value = {"bulk"},
+  produces = {"application/json"}
+)
+public class BulkStatusController {
+  /** The list of valid values for the Accept header for an $export request. */
+  private static List<String> VALID_ACCEPT_HEADER_VALUES =
+      List.of("application/fhir+json", "application/json");
+
+  private final StatusRepository repository;
+
+  private final String bulkFileBaseUrl;
+
+  private final IdentityService identityService;
+
+  @Builder
+  BulkStatusController(
+      @Value("${incrediblebulk.public-url}") String bulkBaseUrl,
+      // TODO need to add to application.properties
+      @Value("${incrediblebulk.public-bulk-file-path:/services/fhir/v0/dstu2/bulk/publication}")
+          String bulkFileUrlPath,
+      @Autowired StatusRepository repository,
+      @Autowired IdentityService identityService) {
+    this.bulkFileBaseUrl = bulkBaseUrl + bulkFileUrlPath;
+    this.repository = repository;
+    this.identityService = identityService;
+  }
+
+  /**
+   * Build and return the bulk status response.
+   *
+   * @param publicationRequestString The encoded publication request containing the original kick-off request and the publication id to retrieve
+   * @return The publication file status with a link to all of the relevant files
+   */
+  @GetMapping(path = "{id}")
+  public ResponseEntity<PublicationFileStatusResponse> getBulkStatus(
+      @PathVariable("id") String publicationRequestString) {
+    // TODO move this to decodePublicationRequest() method and check we get results, etc.
+    ResourceIdentity publicationRequest = identityService.lookup(publicationRequestString).get(0);
+    // TODO move this to createFileOutputList() method and make sure we find publications
+    List<StatusEntity> fileStatuses =
+        repository.findByPublicationId(publicationRequest.identifier());
+    List<PublicationFileStatusResponse.FileLocation> outputFiles =
+        fileStatuses
+            .stream()
+            .map(
+                (a) ->
+                    PublicationFileStatusResponse.FileLocation.builder()
+                        .type("PATIENT")
+                        .url(bulkFileBaseUrl + "/" + a.publicationId() + "/" + a.fileName())
+                        .build())
+            .collect(Collectors.toList());
+    return ResponseEntity.ok(
+        PublicationFileStatusResponse.builder()
+            .requiresAccessToken(true)
+            .request(publicationRequest.resource())
+            .creationDate(Instant.ofEpochMilli(fileStatuses.get(0).publicationEpoch()))
+            .output(outputFiles)
+            .build());
+  }
+}

--- a/the-incredible-bulk/src/main/java/gov/va/api/health/bulkfhir/service/controller/bulkstatus/BulkStatusController.java
+++ b/the-incredible-bulk/src/main/java/gov/va/api/health/bulkfhir/service/controller/bulkstatus/BulkStatusController.java
@@ -141,7 +141,7 @@ public class BulkStatusController {
         PublicationFileStatusResponse.builder()
             .requiresAccessToken(true)
             .request(bulkBaseUrl + publicationRequest.resource())
-            .creationDate(Instant.ofEpochMilli(firstStatusEntity.publicationEpoch()))
+            .transactionTime(Instant.ofEpochMilli(firstStatusEntity.publicationEpoch()))
             .output(outputFiles)
             /* Error is required, but will remain empty */
             .error(List.of())

--- a/the-incredible-bulk/src/main/java/gov/va/api/health/bulkfhir/service/controller/bulkstatus/BulkStatusController.java
+++ b/the-incredible-bulk/src/main/java/gov/va/api/health/bulkfhir/service/controller/bulkstatus/BulkStatusController.java
@@ -114,7 +114,7 @@ public class BulkStatusController {
   public ResponseEntity<PublicationFileStatusResponse> getBulkStatus(
       @RequestHeader("Accept") String acceptHeader,
       @PathVariable("id") String publicationRequestString) {
-    //TODO add to bulk script + IT + manual testing
+    // TODO add IT + double check on ID/name for publication extension data
     if (!VALID_ACCEPT_HEADER_VALUES.contains(acceptHeader)) {
       log.info("Invalid Accept header received for bulk status request");
       return new ResponseEntity<>(HttpStatus.BAD_REQUEST);

--- a/the-incredible-bulk/src/main/java/gov/va/api/health/bulkfhir/service/controller/bulkstatus/BulkStatusController.java
+++ b/the-incredible-bulk/src/main/java/gov/va/api/health/bulkfhir/service/controller/bulkstatus/BulkStatusController.java
@@ -114,7 +114,6 @@ public class BulkStatusController {
   public ResponseEntity<PublicationFileStatusResponse> getBulkStatus(
       @RequestHeader("Accept") String acceptHeader,
       @PathVariable("id") String publicationRequestString) {
-    // TODO add IT + double check on ID/name for publication extension data
     if (!VALID_ACCEPT_HEADER_VALUES.contains(acceptHeader)) {
       log.info("Invalid Accept header received for bulk status request");
       return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
@@ -145,6 +144,8 @@ public class BulkStatusController {
             .request(bulkBaseUrl + publicationRequest.resource())
             .creationDate(Instant.ofEpochMilli(firstStatusEntity.publicationEpoch()))
             .output(outputFiles)
+            /* Error is required, but will remain empty */
+            .error(List.of())
             .extension(
                 PublicationFileStatusResponse.Extension.builder()
                     .creationDate(Instant.ofEpochMilli(firstStatusEntity.publicationEpoch()))

--- a/the-incredible-bulk/src/main/java/gov/va/api/health/bulkfhir/service/controller/bulkstatus/BulkStatusController.java
+++ b/the-incredible-bulk/src/main/java/gov/va/api/health/bulkfhir/service/controller/bulkstatus/BulkStatusController.java
@@ -49,8 +49,7 @@ public class BulkStatusController {
   @Builder
   BulkStatusController(
       @Value("${incrediblebulk.public-url}") String bulkBaseUrl,
-      @Value("${incrediblebulk.public-bulk-file-path:/services/fhir/v0/dstu2/bulk/publication}")
-          String bulkFileUrlPath,
+      @Value("${incrediblebulk.public-bulk-file-path}") String bulkFileUrlPath,
       @Autowired StatusRepository repository,
       @Autowired IdentityService identityService) {
     this.bulkBaseUrl = bulkBaseUrl;

--- a/the-incredible-bulk/src/main/java/gov/va/api/health/bulkfhir/service/controller/bulkstatus/BulkStatusController.java
+++ b/the-incredible-bulk/src/main/java/gov/va/api/health/bulkfhir/service/controller/bulkstatus/BulkStatusController.java
@@ -1,10 +1,13 @@
 package gov.va.api.health.bulkfhir.service.controller.bulkstatus;
 
+import gov.va.api.health.autoconfig.logging.Loggable;
 import gov.va.api.health.bulkfhir.api.bulkstatus.PublicationFileStatusResponse;
 import gov.va.api.health.bulkfhir.service.status.StatusEntity;
 import gov.va.api.health.bulkfhir.service.status.StatusRepository;
 import gov.va.api.health.ids.api.IdentityService;
+import gov.va.api.health.ids.api.IdentityService.LookupFailed;
 import gov.va.api.health.ids.api.ResourceIdentity;
+import gov.va.api.health.ids.client.IdEncoder.BadId;
 import java.time.Instant;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -12,26 +15,32 @@ import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @Validated
 @RestController
+@Loggable
 @RequestMapping(
   value = {"bulk"},
   produces = {"application/json"}
 )
 public class BulkStatusController {
+
   /** The list of valid values for the Accept header for an $export request. */
   private static List<String> VALID_ACCEPT_HEADER_VALUES =
       List.of("application/fhir+json", "application/json");
 
   private final StatusRepository repository;
+
+  private final String bulkBaseUrl;
 
   private final String bulkFileBaseUrl;
 
@@ -40,14 +49,58 @@ public class BulkStatusController {
   @Builder
   BulkStatusController(
       @Value("${incrediblebulk.public-url}") String bulkBaseUrl,
-      // TODO need to add to application.properties
       @Value("${incrediblebulk.public-bulk-file-path:/services/fhir/v0/dstu2/bulk/publication}")
           String bulkFileUrlPath,
       @Autowired StatusRepository repository,
       @Autowired IdentityService identityService) {
+    this.bulkBaseUrl = bulkBaseUrl;
     this.bulkFileBaseUrl = bulkBaseUrl + bulkFileUrlPath;
     this.repository = repository;
     this.identityService = identityService;
+  }
+
+  /**
+   * Convert the list of publication file status objects to output FileLocations.
+   *
+   * @param fileStatuses The file statuses to convert
+   * @return A list of FileLocation with the appropriate fully qualified URL to the file.
+   */
+  private List<PublicationFileStatusResponse.FileLocation> createFileOutputList(
+      List<StatusEntity> fileStatuses) {
+    return fileStatuses
+        .stream()
+        .map(
+            (file) ->
+                PublicationFileStatusResponse.FileLocation.builder()
+                    .type("Patient")
+                    .url(
+                        bulkFileBaseUrl
+                            + "/"
+                            + file.publicationId()
+                            + "/"
+                            + file.fileName()
+                            + ".ndjson")
+                    .build())
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Decode the publication request string into a ResourceIdentity object.
+   *
+   * @param publicationRequestString The string to decode
+   * @return The decoded ResourceIdentity or null if one could not be found.
+   */
+  private ResourceIdentity decodePublicationRequest(String publicationRequestString) {
+    try {
+      List<ResourceIdentity> foundIdentities = identityService.lookup(publicationRequestString);
+      if (foundIdentities == null || foundIdentities.isEmpty()) {
+        return null;
+      }
+      return foundIdentities.get(0);
+    } catch (BadId | LookupFailed e) {
+      log.error("Failed to decode publication request string {}", publicationRequestString, e);
+      return null;
+    }
   }
 
   /**
@@ -59,33 +112,44 @@ public class BulkStatusController {
    */
   @GetMapping(path = "{id}")
   public ResponseEntity<PublicationFileStatusResponse> getBulkStatus(
+      @RequestHeader("Accept") String acceptHeader,
       @PathVariable("id") String publicationRequestString) {
-    // TODO move this to decodePublicationRequest() method and check we get results, etc.
-    ResourceIdentity publicationRequest = identityService.lookup(publicationRequestString).get(0);
-    // TODO move this to createFileOutputList() method and make sure we find publications
+    //TODO add to bulk script + IT + manual testing
+    if (!VALID_ACCEPT_HEADER_VALUES.contains(acceptHeader)) {
+      log.info("Invalid Accept header received for bulk status request");
+      return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+    }
+
+    ResourceIdentity publicationRequest = decodePublicationRequest(publicationRequestString);
+    if (publicationRequest == null) {
+      return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+    }
     List<StatusEntity> fileStatuses =
         repository.findByPublicationId(publicationRequest.identifier());
+    if (fileStatuses == null || fileStatuses.isEmpty()) {
+      /*
+       * No statuses were found for the given publication id
+       */
+      log.info("No publication data found for publication {}", publicationRequest.identifier());
+      return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+    }
     List<PublicationFileStatusResponse.FileLocation> outputFiles =
-        fileStatuses
-            .stream()
-            .map(
-                (a) ->
-                    PublicationFileStatusResponse.FileLocation.builder()
-                        .type("PATIENT")
-                        .url(bulkFileBaseUrl + "/" + a.publicationId() + "/" + a.fileName())
-                        .build())
-            .collect(Collectors.toList());
+        createFileOutputList(fileStatuses);
+    /*
+     * Pull out the first status entity to use for the boiler plate information of the response
+     */
+    StatusEntity firstStatusEntity = fileStatuses.get(0);
     return ResponseEntity.ok(
         PublicationFileStatusResponse.builder()
             .requiresAccessToken(true)
-            .request(publicationRequest.resource())
-            .creationDate(Instant.ofEpochMilli(fileStatuses.get(0).publicationEpoch()))
+            .request(bulkBaseUrl + publicationRequest.resource())
+            .creationDate(Instant.ofEpochMilli(firstStatusEntity.publicationEpoch()))
             .output(outputFiles)
             .extension(
                 PublicationFileStatusResponse.Extension.builder()
-                    .creationDate(Instant.ofEpochMilli(fileStatuses.get(0).publicationEpoch()))
-                    .id(fileStatuses.get(0).publicationId())
-                    .recordsPerFile(fileStatuses.get(0).recordsPerFile())
+                    .creationDate(Instant.ofEpochMilli(firstStatusEntity.publicationEpoch()))
+                    .id(firstStatusEntity.publicationId())
+                    .recordsPerFile(firstStatusEntity.recordsPerFile())
                     .build())
             .build());
   }

--- a/the-incredible-bulk/src/main/java/gov/va/api/health/bulkfhir/service/controller/bulkstatus/BulkStatusController.java
+++ b/the-incredible-bulk/src/main/java/gov/va/api/health/bulkfhir/service/controller/bulkstatus/BulkStatusController.java
@@ -10,6 +10,7 @@ import gov.va.api.health.ids.api.ResourceIdentity;
 import gov.va.api.health.ids.client.IdEncoder.BadId;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
@@ -146,11 +147,12 @@ public class BulkStatusController {
             /* Error is required, but will remain empty */
             .error(List.of())
             .extension(
-                PublicationFileStatusResponse.Extension.builder()
-                    .creationDate(Instant.ofEpochMilli(firstStatusEntity.publicationEpoch()))
-                    .id(firstStatusEntity.publicationId())
-                    .recordsPerFile(firstStatusEntity.recordsPerFile())
-                    .build())
+                Optional.of(
+                    PublicationFileStatusResponse.Extension.builder()
+                        .creationDate(Instant.ofEpochMilli(firstStatusEntity.publicationEpoch()))
+                        .id(firstStatusEntity.publicationId())
+                        .recordsPerFile(firstStatusEntity.recordsPerFile())
+                        .build()))
             .build());
   }
 }

--- a/the-incredible-bulk/src/main/java/gov/va/api/health/bulkfhir/service/controller/bulkstatus/BulkStatusController.java
+++ b/the-incredible-bulk/src/main/java/gov/va/api/health/bulkfhir/service/controller/bulkstatus/BulkStatusController.java
@@ -53,7 +53,8 @@ public class BulkStatusController {
   /**
    * Build and return the bulk status response.
    *
-   * @param publicationRequestString The encoded publication request containing the original kick-off request and the publication id to retrieve
+   * @param publicationRequestString The encoded publication request containing the original
+   *     kick-off request and the publication id to retrieve
    * @return The publication file status with a link to all of the relevant files
    */
   @GetMapping(path = "{id}")
@@ -80,6 +81,12 @@ public class BulkStatusController {
             .request(publicationRequest.resource())
             .creationDate(Instant.ofEpochMilli(fileStatuses.get(0).publicationEpoch()))
             .output(outputFiles)
+            .extension(
+                PublicationFileStatusResponse.Extension.builder()
+                    .creationDate(Instant.ofEpochMilli(fileStatuses.get(0).publicationEpoch()))
+                    .id(fileStatuses.get(0).publicationId())
+                    .recordsPerFile(fileStatuses.get(0).recordsPerFile())
+                    .build())
             .build());
   }
 }

--- a/the-incredible-bulk/src/main/java/gov/va/api/health/bulkfhir/service/controller/patient/BulkPatientController.java
+++ b/the-incredible-bulk/src/main/java/gov/va/api/health/bulkfhir/service/controller/patient/BulkPatientController.java
@@ -58,8 +58,7 @@ class BulkPatientController {
   @Builder
   BulkPatientController(
       @Value("${incrediblebulk.public-url}") String baseUrl,
-      @Value("${incrediblebulk.public-bulk-status-path:/services/fhir/v0/dstu2/bulk}")
-          String bulkStatusPath,
+      @Value("${incrediblebulk.public-bulk-status-path}") String bulkStatusPath,
       @Autowired StatusRepository repository,
       @Autowired IdentityService identityService,
       @Autowired(required = false) PublicationStatusTransformer transformer) {

--- a/the-incredible-bulk/src/main/resources/application.properties
+++ b/the-incredible-bulk/src/main/resources/application.properties
@@ -45,8 +45,8 @@ logging.level.liquibase.executor=INFO
 
 bulk.file.writer=local
 incrediblebulk.public-url=unset
-incrediblebulk.public-bulk-status-path=/services/fhir/v0/dstu2/bulk
-incrediblebulk.public-bulk-file-path=/services/fhir/v0/dstu2/bulk/publication
+incrediblebulk.public-bulk-status-path=unset
+incrediblebulk.public-bulk-file-path=unset
 
 #
 # S3 Configuration

--- a/the-incredible-bulk/src/main/resources/application.properties
+++ b/the-incredible-bulk/src/main/resources/application.properties
@@ -46,6 +46,7 @@ logging.level.liquibase.executor=INFO
 bulk.file.writer=local
 incrediblebulk.public-url=unset
 incrediblebulk.public-bulk-status-path=/services/fhir/v0/dstu2/bulk
+incrediblebulk.public-bulk-file-path=/services/fhir/v0/dstu2/bulk/publication
 
 #
 # S3 Configuration

--- a/the-incredible-bulk/src/test/java/gov/va/api/health/bulkfhir/service/controller/bulkstatus/BulkStatusControllerTest.java
+++ b/the-incredible-bulk/src/test/java/gov/va/api/health/bulkfhir/service/controller/bulkstatus/BulkStatusControllerTest.java
@@ -116,7 +116,7 @@ public class BulkStatusControllerTest {
         PublicationFileStatusResponse.builder()
             .requiresAccessToken(true)
             .request("http://fake-va.gov/test")
-            .creationDate(Instant.ofEpochMilli(now))
+            .transactionTime(Instant.ofEpochMilli(now))
             .output(
                 List.of(
                     PublicationFileStatusResponse.FileLocation.builder()

--- a/the-incredible-bulk/src/test/java/gov/va/api/health/bulkfhir/service/controller/bulkstatus/BulkStatusControllerTest.java
+++ b/the-incredible-bulk/src/test/java/gov/va/api/health/bulkfhir/service/controller/bulkstatus/BulkStatusControllerTest.java
@@ -1,11 +1,10 @@
-package gov.va.api.health.bulkfhir.service.controller.patient;
+package gov.va.api.health.bulkfhir.service.controller.bulkstatus;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import gov.va.api.health.bulkfhir.api.bulkstatus.PublicationFileStatusResponse;
-import gov.va.api.health.bulkfhir.service.controller.bulkstatus.BulkStatusController;
 import gov.va.api.health.bulkfhir.service.status.StatusEntity;
 import gov.va.api.health.bulkfhir.service.status.StatusRepository;
 import gov.va.api.health.ids.api.IdentityService;
@@ -13,6 +12,7 @@ import gov.va.api.health.ids.api.ResourceIdentity;
 import gov.va.api.health.ids.client.IdEncoder;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -125,11 +125,12 @@ public class BulkStatusControllerTest {
                         .build()))
             .error(List.of())
             .extension(
-                PublicationFileStatusResponse.Extension.builder()
-                    .creationDate(Instant.ofEpochMilli(now))
-                    .id("EXPOSED")
-                    .recordsPerFile(10)
-                    .build())
+                Optional.of(
+                    PublicationFileStatusResponse.Extension.builder()
+                        .creationDate(Instant.ofEpochMilli(now))
+                        .id("EXPOSED")
+                        .recordsPerFile(10)
+                        .build()))
             .build();
     assertThat(response.getStatusCodeValue()).isEqualTo(200);
     assertThat(response.getBody()).isEqualTo(expected);

--- a/the-incredible-bulk/src/test/java/gov/va/api/health/bulkfhir/service/controller/bulkstatus/BulkStatusControllerTest.java
+++ b/the-incredible-bulk/src/test/java/gov/va/api/health/bulkfhir/service/controller/bulkstatus/BulkStatusControllerTest.java
@@ -123,6 +123,7 @@ public class BulkStatusControllerTest {
                         .type("Patient")
                         .url("http://fake-va.gov/bulk/publication/EXPOSED/FILE1.ndjson")
                         .build()))
+            .error(List.of())
             .extension(
                 PublicationFileStatusResponse.Extension.builder()
                     .creationDate(Instant.ofEpochMilli(now))

--- a/the-incredible-bulk/src/test/java/gov/va/api/health/bulkfhir/service/controller/bulkstatus/BulkStatusControllerTest.java
+++ b/the-incredible-bulk/src/test/java/gov/va/api/health/bulkfhir/service/controller/bulkstatus/BulkStatusControllerTest.java
@@ -1,0 +1,136 @@
+package gov.va.api.health.bulkfhir.service.controller.patient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import gov.va.api.health.bulkfhir.api.bulkstatus.PublicationFileStatusResponse;
+import gov.va.api.health.bulkfhir.service.controller.bulkstatus.BulkStatusController;
+import gov.va.api.health.bulkfhir.service.status.StatusEntity;
+import gov.va.api.health.bulkfhir.service.status.StatusRepository;
+import gov.va.api.health.ids.api.IdentityService;
+import gov.va.api.health.ids.api.ResourceIdentity;
+import gov.va.api.health.ids.client.IdEncoder;
+import java.time.Instant;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+@ExtendWith(MockitoExtension.class)
+public class BulkStatusControllerTest {
+
+  @Mock StatusRepository repo;
+
+  @Mock HttpServletRequest request;
+
+  @Mock IdentityService identityService;
+
+  BulkStatusController controller() {
+    return BulkStatusController.builder()
+        .repository(repo)
+        .bulkBaseUrl("http://fake-va.gov")
+        .bulkFileUrlPath("/bulk/publication")
+        .identityService(identityService)
+        .build();
+  }
+
+  @Test
+  void getBulkStatusReturns400WhenInvalidAcceptHeaderIsProvided() {
+    ResponseEntity<PublicationFileStatusResponse> response =
+        controller().getBulkStatus("whatevah", "BOOM");
+    assertThat(response.getStatusCodeValue()).isEqualTo(400);
+    assertThat(response.getBody()).isNull();
+  }
+
+  @Test
+  void getBulkStatusReturns404WhenNoPublicationStatusEntitiesAreFound() {
+    when(identityService.lookup(any()))
+        .thenReturn(
+            List.of(
+                ResourceIdentity.builder()
+                    .identifier("EXPOSED")
+                    .resource("test.gov")
+                    .system("BULK")
+                    .build()));
+    when(repo.findByPublicationId("EXPOSED")).thenReturn(List.of());
+    ResponseEntity<PublicationFileStatusResponse> response =
+        controller().getBulkStatus("application/json", "CRACKME");
+    assertThat(response.getStatusCodeValue()).isEqualTo(404);
+    assertThat(response.getBody()).isNull();
+  }
+
+  @Test
+  void getBulkStatusReturns404WhenPublicationLookupReturnsNoResults() {
+    when(identityService.lookup(any())).thenReturn(List.of());
+    ResponseEntity<PublicationFileStatusResponse> response =
+        controller().getBulkStatus("application/fhir+json", "empty");
+    assertThat(response.getStatusCodeValue()).isEqualTo(404);
+    assertThat(response.getBody()).isNull();
+  }
+
+  @Test
+  void getBulkStatusReturns404WhenPublicationLookupReturnsNull() {
+    when(identityService.lookup(any())).thenReturn(null);
+    ResponseEntity<PublicationFileStatusResponse> response =
+        controller().getBulkStatus("application/fhir+json", "cantcrackme");
+    assertThat(response.getStatusCodeValue()).isEqualTo(404);
+    assertThat(response.getBody()).isNull();
+  }
+
+  @Test
+  void getBulkStatusReturns404WhenPublicationStringCouldNotBeDecoded() {
+    when(identityService.lookup(any())).thenThrow(new IdEncoder.BadId("WAT IS THIS"));
+    ResponseEntity<PublicationFileStatusResponse> response =
+        controller().getBulkStatus("application/fhir+json", "NODECODE");
+    assertThat(response.getStatusCodeValue()).isEqualTo(404);
+    assertThat(response.getBody()).isNull();
+  }
+
+  @Test
+  void getBulkStatusReturnsAppropriateSuccessfulResponse() {
+    long now = Instant.now().toEpochMilli();
+    when(identityService.lookup(any()))
+        .thenReturn(
+            List.of(
+                ResourceIdentity.builder()
+                    .identifier("EXPOSED")
+                    .resource("/test")
+                    .system("BULK")
+                    .build()));
+    when(repo.findByPublicationId("EXPOSED"))
+        .thenReturn(
+            List.of(
+                StatusEntity.builder()
+                    .publicationEpoch(now)
+                    .fileName("FILE1")
+                    .publicationId("EXPOSED")
+                    .recordsPerFile(10)
+                    .build()));
+    ResponseEntity<PublicationFileStatusResponse> response =
+        controller().getBulkStatus("application/fhir+json", "CRACKME");
+    PublicationFileStatusResponse expected =
+        PublicationFileStatusResponse.builder()
+            .requiresAccessToken(true)
+            .request("http://fake-va.gov/test")
+            .creationDate(Instant.ofEpochMilli(now))
+            .output(
+                List.of(
+                    PublicationFileStatusResponse.FileLocation.builder()
+                        .type("Patient")
+                        .url("http://fake-va.gov/bulk/publication/EXPOSED/FILE1.ndjson")
+                        .build()))
+            .extension(
+                PublicationFileStatusResponse.Extension.builder()
+                    .creationDate(Instant.ofEpochMilli(now))
+                    .id("EXPOSED")
+                    .recordsPerFile(10)
+                    .build())
+            .build();
+    assertThat(response.getStatusCodeValue()).isEqualTo(200);
+    assertThat(response.getBody()).isEqualTo(expected);
+  }
+}


### PR DESCRIPTION
This value will need to be added to the deployment information because it will vary by environment:

incrediblebulk.public-bulk-file-path=/services/fhir/v0/dstu2/bulk/publication


Sample output:
```
{
  "requiresAccessToken": true,
  "request": "http://localhost:8091/Patient/$export?_outputFormat=ndjson",
  "transactionTime": 1574698948.566,
  "output": [
    {
      "type": "Patient",
      "url": "http://localhost:8091/bulk/publication/testpub1/Patient-0001.ndjson"
    }
  ],
  "error": [],
  "extension": {
    "id": "testpub1",
    "recordsPerFile": 100,
    "creationDate": 1574698948.566
  }
}
```