### PR TITLE
publication max file count constraints

### DIFF
--- a/the-incredible-bulk/src/main/java/gov/va/api/health/bulkfhir/service/controller/publication/PublicationExceptions.java
+++ b/the-incredible-bulk/src/main/java/gov/va/api/health/bulkfhir/service/controller/publication/PublicationExceptions.java
@@ -11,6 +11,13 @@ public class PublicationExceptions {
     }
   }
 
+  static void assertFileCount(int recordsPerFile, int resourceCount, int maxFileCount) {
+    var fileCount = resourceCount / recordsPerFile;
+    if (fileCount > maxFileCount) {
+      throw new PublicationFileCountTooBig(fileCount, maxFileCount);
+    }
+  }
+
   static void assertPublicationFileFound(boolean found, String publicationId, String fileId) {
     if (!found) {
       throw new PublicationFileNotFound(publicationId, fileId);
@@ -26,6 +33,13 @@ public class PublicationExceptions {
   static void assertRecordsPerFile(int recordsPerFile, int maxAllowed) {
     if (recordsPerFile > maxAllowed) {
       throw new PublicationRecordsPerFileTooBig(recordsPerFile, maxAllowed);
+    }
+  }
+
+  public static class PublicationFileCountTooBig extends PublicationException {
+
+    public PublicationFileCountTooBig(int fileCount, int max) {
+      super("Requested Files:" + fileCount + ", max allowed: " + max);
     }
   }
 

--- a/the-incredible-bulk/src/main/resources/application.properties
+++ b/the-incredible-bulk/src/main/resources/application.properties
@@ -47,6 +47,7 @@ bulk.file.writer=local
 incrediblebulk.public-url=unset
 incrediblebulk.public-bulk-status-path=unset
 incrediblebulk.public-bulk-file-path=unset
+incrediblebulk.publication-max-file-count=5000
 
 #
 # Anonymization


### PR DESCRIPTION
Provide a maximum file count constraint so that publications can not result in _unacceptably_ large sets of files.

I've gone with 5000 as a max for now. Can be configured per environment.

Follow-up changes to the DU after approval.